### PR TITLE
Upper bounds for final Julia 0.6-compatible release

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,7 +1,8 @@
 julia 0.6
 Reexport 0.1.0
 
-IntervalArithmetic 0.13.0
-IntervalRootFinding 0.2.0
-IntervalContractors 0.2.0
-IntervalConstraintProgramming 0.7.0
+IntervalArithmetic 0.13.0 0.14.0
+IntervalRootFinding 0.2.0 0.2.1
+IntervalContractors 0.2.0 0.2.1
+IntervalConstraintProgramming 0.7.0 0.7.1
+IntervalOptimisation 0.1.0

--- a/REQUIRE
+++ b/REQUIRE
@@ -2,7 +2,7 @@ julia 0.6
 Reexport 0.1.0
 
 IntervalArithmetic 0.13.0 0.14.0
-IntervalRootFinding 0.2.0 0.2.1
-IntervalContractors 0.2.0 0.2.1
-IntervalConstraintProgramming 0.7.0 0.8.0
-IntervalOptimisation 0.1.0 0.2.0
+IntervalRootFinding 0.2.0 0.3
+IntervalContractors 0.2.0 0.3
+IntervalConstraintProgramming 0.8.0 0.9.0
+IntervalOptimisation 0.2.0 0.3.0

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,8 +1,9 @@
-julia 0.6
-Reexport 0.1.0
+julia 0.6 0.7
 
-IntervalArithmetic 0.13.0 0.14.0
-IntervalRootFinding 0.2.0 0.3
-IntervalContractors 0.2.0 0.3
-IntervalConstraintProgramming 0.8.0 0.9.0
-IntervalOptimisation 0.2.0 0.3.0
+Reexport 0.1 0.2
+
+IntervalArithmetic 0.13 0.14
+IntervalRootFinding 0.2 0.3
+IntervalContractors 0.2 0.3
+IntervalConstraintProgramming 0.8 0.9
+IntervalOptimisation 0.2 0.3

--- a/REQUIRE
+++ b/REQUIRE
@@ -4,5 +4,5 @@ Reexport 0.1.0
 IntervalArithmetic 0.13.0 0.14.0
 IntervalRootFinding 0.2.0 0.2.1
 IntervalContractors 0.2.0 0.2.1
-IntervalConstraintProgramming 0.7.0 0.7.1
-IntervalOptimisation 0.1.0
+IntervalConstraintProgramming 0.7.0 0.7.0
+IntervalOptimisation 0.1.0 0.1.0

--- a/REQUIRE
+++ b/REQUIRE
@@ -4,5 +4,5 @@ Reexport 0.1.0
 IntervalArithmetic 0.13.0 0.14.0
 IntervalRootFinding 0.2.0 0.2.1
 IntervalContractors 0.2.0 0.2.1
-IntervalConstraintProgramming 0.7.0 0.7.0
-IntervalOptimisation 0.1.0 0.1.0
+IntervalConstraintProgramming 0.7.0
+IntervalOptimisation 0.1.0

--- a/REQUIRE
+++ b/REQUIRE
@@ -4,5 +4,5 @@ Reexport 0.1.0
 IntervalArithmetic 0.13.0 0.14.0
 IntervalRootFinding 0.2.0 0.2.1
 IntervalContractors 0.2.0 0.2.1
-IntervalConstraintProgramming 0.7.0
-IntervalOptimisation 0.1.0
+IntervalConstraintProgramming 0.7.0 0.8.0
+IntervalOptimisation 0.1.0 0.2.0


### PR DESCRIPTION
This should make easier to upgrade for compatibility with Julia 0.7 and 1.0